### PR TITLE
[PY-146] 카테고리 api 연동 코드 및 id 수정

### DIFF
--- a/my-app/src/screens/CategoryLessonScreen.js
+++ b/my-app/src/screens/CategoryLessonScreen.js
@@ -98,24 +98,23 @@ export default function CategoryLessonScreen({ navigation, route }) {
 
         // 카테고리 지정된 경우
         if (category !== "전체" && categoryId) {
-          endpoint = `${BASE_URL}/courses/category/${categoryId}/${sortParam}`;
+          endpoint = `${BASE_URL}/courses/category/${categoryId}${sortParam}`;
         }
         // 전체(기본값)일 경우 → /my/home/에서 인기 강의만 뽑기
         else {
           endpoint = `${BASE_URL}/my/home/`;
         }
 
+        // 백엔드 수정 시 위 코드 제거 후 이 코드 활성화
+        // endpoint = `${BASE_URL}/courses/category/${categoryId}/${sortParam}`;
+
         const res = await axios.get(endpoint);
-        let data = [];
+        let data = res.data.courses ?? [];
 
         // category별 API가 없으면 /my/home/의 popular_courses 사용
+        // 백엔드 수정 시 이 부분 제거
         if (category === "전체" || !categoryId) {
           data = res.data.popular_courses ?? [];
-        } else {
-          // category API 응답이 리스트 형식이라면 바로 사용
-          data = Array.isArray(res.data)
-            ? res.data
-            : res.data.results ?? [];
         }
         
         // 서버 응답 데이터 정규화

--- a/my-app/src/screens/CategoryMenu.js
+++ b/my-app/src/screens/CategoryMenu.js
@@ -19,13 +19,13 @@ import { Ionicons } from "@expo/vector-icons"; // 아이콘 컴포넌트 (X 버�
 
 // 고정 카테고리 데이터 (프론트 상수)
 const STATIC_CATEGORIES = [
-  { id: 1, name: "전체", icon: "📚" },
-  { id: 2, name: "음악", icon: "🎵" },
-  { id: 3, name: "운동", icon: "🏃" },
-  { id: 4, name: "예술", icon: "🎨" },
-  { id: 5, name: "프로그래밍", icon: "💻" },
-  { id: 6, name: "금융/재테크", icon: "💰" },
-  { id: 7, name: "외국어", icon: "🌍" },
+  { id: 0, name: "전체", icon: "📚" },
+  { id: 1, name: "음악", icon: "🎵" },
+  { id: 2, name: "운동", icon: "🏃" },
+  { id: 3, name: "예술", icon: "🎨" },
+  { id: 4, name: "프로그래밍", icon: "💻" },
+  { id: 5, name: "금융/재테크", icon: "💰" },
+  { id: 6, name: "외국어", icon: "🌍" },
 ];
 
 export default function CategoryMenu({ visible, onClose, navigation }) {


### PR DESCRIPTION
## #️⃣ Issue Number

PY-146

## 📝 요약(Summary)

카테고리 별 과외 페이지에 과외들이 잘 나오지 않던 부분들을 수정했습니다.

1. CategoryMenu.js 파일에서 각 카테고리의 id를 수정하였습니다.
2. CategoryLessonScreen.js 파일에서 api 호출 부분을 수정하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
1. settings.py에는 'rest_framework_simplejwt' 이 추가되어 있는데, requirements.txt 에는 djangorestframework-simplejwt 이 추가가 되지 않아, migrate 시 오류가 발생합니다.

2. back-end/courses/urls.py 의 path('category/<int:category_id>',course_list_by_category), 부분에 category/<int:category_id> 여기 마지막에 '/' 가 빠진 것 같습니다.
<img width="714" height="42" alt="image" src="https://github.com/user-attachments/assets/b5882ec0-93b4-4a6b-bea6-65e56fa7795f" />


3. 카테고리 api 호출 시 전체에 해당하는 로직이 없는 것 같습니다. categories.csv 파일이 다음과 같이 구성되어있는데, id=0, name=전체 처럼 추가해놓으면 좋지 않을까 라는 생각입니다.
그리고 id=7의 기타라는 카테고리를 더 추가할 것인지 궁금합니다. 그럼 프론트 코드에 더 수정이 필요해서요.
<img width="165" height="237" alt="image" src="https://github.com/user-attachments/assets/3ae89c42-da1b-4fb7-b140-5726d458e178" />


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
