### PR TITLE
[PY-154] 회원 인증 api 연동

### DIFF
--- a/my-app/src/config/config.js
+++ b/my-app/src/config/config.js
@@ -10,7 +10,7 @@
 // ⚠️ 주의: IP 변경 시 서버 재시작 필요
 // ⚠️ 주의: 배포 시에는 고정 IP 또는 도메인 사용 권장
 // ⚠️ 주의: 커밋 시 본인 IP가 노출되지 않도록 주의
-export const PC_IP = "192.168.208.82";
+export const PC_IP = "";
 
 // API 엔드포인트 기본 주소
 export const BASE_URL = `http://${PC_IP}:8000/api`;

--- a/my-app/src/navigation/RootNavigator.js
+++ b/my-app/src/navigation/RootNavigator.js
@@ -1,8 +1,12 @@
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
-import { Ionicons } from "@expo/vector-icons"; // 아이콘 패키지
+import { Ionicons } from "@expo/vector-icons";
 import { TouchableOpacity, View } from "react-native";
+import { useEffect } from "react";
+
+// 🔥 토큰 유틸
+import { getAccessToken, getRefreshToken } from "../utils/tokenStorage";
 
 // Screens
 import LoginScreen from "../screens/LoginScreen";
@@ -24,10 +28,14 @@ import SearchScreen from "../screens/SearchScreen";
 const Stack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
 
+/* -------------------------------
+   하단 탭 네비게이터(MainTabs)
+-------------------------------- */
 function MainTabs() {
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
+        // 아이콘 설정
         tabBarIcon: ({ color, size }) => {
           let iconName;
           if (route.name === "Home") iconName = "home";
@@ -39,6 +47,7 @@ function MainTabs() {
         },
         tabBarActiveTintColor: "tomato",
         tabBarInactiveTintColor: "gray",
+        headerShown: true, // 탭 내부 화면 헤더 표시
       })}
     >
       <Tab.Screen
@@ -46,6 +55,7 @@ function MainTabs() {
         component={HomeScreen}
         options={({ navigation }) => ({
           title: "홈",
+          // 홈 화면 우측 상단 버튼 영역
           headerRight: () => (
             <View style={{ flexDirection: "row", alignItems: "center" }}>
               <TouchableOpacity
@@ -64,16 +74,19 @@ function MainTabs() {
           ),
         })}
       />
+
       <Tab.Screen
         name="LessonCreate"
         component={LessonCreateScreen}
         options={{ title: "과외 생성" }}
       />
+
       <Tab.Screen
         name="ChatList"
         component={ChatListScreen}
         options={{ title: "채팅" }}
       />
+
       <Tab.Screen
         name="MyPage"
         component={MyPageScreen}
@@ -83,17 +96,39 @@ function MainTabs() {
   );
 }
 
+/* -------------------------------
+   Root Navigator
+-------------------------------- */
 export default function RootNavigator() {
   return (
     <NavigationContainer>
       <Stack.Navigator initialRouteName="Login">
-        {/* Auth */}
-        <Stack.Screen name="Login" component={LoginScreen} />
-        <Stack.Screen name="Register" component={RegisterScreen} />
-        <Stack.Screen name="FindId" component={FindIdScreen} />
-        <Stack.Screen name="FindPassword" component={FindPasswordScreen} />
+        
+        {/* 로그인 화면 (헤더 표시) */}
+        <Stack.Screen
+          name="Login"
+          component={LoginScreenWrapper}
+          options={{ title: "로그인" }}
+        />
 
-        {/* Tabs */}
+        {/* Auth */}
+        <Stack.Screen
+          name="Register"
+          component={RegisterScreen}
+          options={{ title: "회원가입" }}
+        />
+        <Stack.Screen
+          name="FindId"
+          component={FindIdScreen}
+          options={{ title: "아이디 찾기" }}
+        />
+        <Stack.Screen
+          name="FindPassword"
+          component={FindPasswordScreen}
+          options={{ title: "비밀번호 찾기" }}
+        />
+
+        {/* 메인 탭 (헤더 숨김) */}
         <Stack.Screen
           name="MainTabs"
           component={MainTabs}
@@ -101,21 +136,51 @@ export default function RootNavigator() {
         />
 
         {/* Extra Screens */}
-        <Stack.Screen name="CategoryLesson" component={CategoryLessonScreen} />
-        <Stack.Screen name="LessonDetail" component={LessonDetailScreen} />
+        <Stack.Screen
+          name="CategoryLesson"
+          component={CategoryLessonScreen}
+          options={{ title: "카테고리" }}
+        />
+        <Stack.Screen
+          name="LessonDetail"
+          component={LessonDetailScreen}
+          options={{ title: "과외 상세" }}
+        />
         <Stack.Screen
           name="AIChatbot"
           component={AIChatbotScreen}
           options={{
-            presentation: "transparentModal", // 투명 배경 허용 -> 아래 화면이 보임
+            presentation: "transparentModal",
             headerShown: false,
           }}
         />
-        <Stack.Screen name="Chat" component={ChatScreen} />
-        <Stack.Screen name="ReviewWrite" component={ReviewWriteScreen} />
-        <Stack.Screen name="Intro" component={IntroScreen} />
-        <Stack.Screen name="Search" component={SearchScreen} />
+        <Stack.Screen name="Chat" component={ChatScreen} options={{ title: "채팅" }} />
+        <Stack.Screen name="ReviewWrite" component={ReviewWriteScreen} options={{ title: "리뷰 작성" }} />
+        <Stack.Screen name="Intro" component={IntroScreen} options={{ title: "소개" }} />
+        <Stack.Screen name="Search" component={SearchScreen} options={{ title: "검색" }} />
       </Stack.Navigator>
     </NavigationContainer>
   );
+}
+
+/* 
+  LoginScreen을 감싸서 토큰 체크 → 자동 로그인 처리하는 래퍼
+  - 앱 처음 실행할 때 refresh 토큰이 있으면 바로 MainTabs로 이동
+  - 토큰이 없으면 LoginScreen 그대로 보여줌
+*/
+function LoginScreenWrapper(props) {
+  const { navigation } = props;
+
+  useEffect(() => {
+    const check = async () => {
+      const refresh = await getRefreshToken();
+      if (refresh) {
+        // 자동 로그인 → 메인 탭으로
+        navigation.replace("MainTabs");
+      }
+    };
+    check();
+  }, [navigation]);
+
+  return <LoginScreen {...props} />;
 }

--- a/my-app/src/screens/LoginScreen.js
+++ b/my-app/src/screens/LoginScreen.js
@@ -1,19 +1,96 @@
-import { View, Text, TextInput, Button, StyleSheet } from "react-native";
+/*
+  LoginScreen 전체 설명 (요약)
+
+  - 사용자가 아이디(username)와 비밀번호(password)를 입력해 로그인하는 화면입니다.
+  - 로그인 API(/my/login/)로 POST 요청을 보내며, 정상적으로 인증되면 access/refresh 토큰을 전달받습니다.
+  - 받은 토큰은 expo-secure-store를 사용해 기기에 안전하게 저장되며, 이후 모든 API 요청에서 자동으로 사용됩니다.
+
+  - 로그인 성공 시 navigation.replace("MainTabs")를 통해 메인 탭(Home, 과외생성, 채팅, 마이페이지) 화면으로 이동합니다.
+  - 입력값이 비어 있을 경우 클라이언트 단에서 Alert를 띄워 즉시 검증합니다.
+  
+  - axiosInstance는 모든 요청에 대해 Authorization 헤더에 Bearer 토큰을 자동으로 포함시키며,
+    토큰 만료 시 refresh 토큰을 이용해 자동 재발급하는 인터셉터를 포함하고 있습니다.
+
+  - UI는 TextInput으로 아이디/비밀번호 입력을 받고, 하단 버튼을 통해 로그인/회원가입 화면으로 이동합니다.
+  - 스타일은 RN 기본 StyleSheet를 사용하여 간단한 로그인 폼 형태로 구성되어 있습니다.
+
+  - 주의: BASE_URL 및 엔드포인트는 개발 환경 기준이며, 배포 시 환경 변수(.env) 기반으로 분리해야 합니다.
+*/
+
+import { useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  Button,
+  StyleSheet,
+  Alert,
+} from "react-native";
+import api from "../utils/axiosInstance";
+import { saveTokens } from "../utils/tokenStorage";
 
 export default function LoginScreen({ navigation }) {
+  // 입력값 상태 관리
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  /**
+   * handleLogin()
+   * - 입력값 유효성 검사
+   * - 로그인 API 호출 (POST /my/login/)
+   * - access / refresh 토큰을 SecureStore에 저장
+   * - 로그인 성공 → MainTabs 화면으로 이동
+   */
+  const handleLogin = async () => {
+    if (!username || !password) {
+      Alert.alert("알림", "아이디와 비밀번호를 입력해주세요.");
+      return;
+    }
+
+    try {
+      // 로그인 API 요청
+      const res = await api.post("/my/login/", { username, password });
+      console.log("LOGIN RESPONSE:", res.data);
+
+      // 토큰 저장
+      await saveTokens(res.data.access, res.data.refresh);
+
+      // 로그인 성공 → 메인 탭으로 이동
+      navigation.replace("MainTabs");
+    } catch (err) {
+      console.log(err.response?.data);
+      Alert.alert("로그인 실패", "아이디 또는 비밀번호를 다시 확인하세요.");
+    }
+  };
+
   return (
     <View style={styles.container}>
+      {/* 타이틀 */}
       <Text style={styles.title}>로그인</Text>
-      <TextInput style={styles.input} placeholder="아이디" />
-      <TextInput style={styles.input} placeholder="비밀번호" secureTextEntry />
 
+      {/* 아이디 입력 */}
+      <TextInput
+        style={styles.input}
+        placeholder="아이디"
+        value={username}
+        onChangeText={setUsername}
+      />
+
+      {/* 비밀번호 입력 */}
+      <TextInput
+        style={styles.input}
+        placeholder="비밀번호"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+      />
+
+      {/* 로그인 버튼 */}
       <View style={styles.btnWrapper}>
-        <Button
-          title="로그인"
-          onPress={() => navigation.replace("MainTabs")}
-        />
+        <Button title="로그인" onPress={handleLogin} />
       </View>
 
+      {/* 회원가입 이동 버튼 */}
       <View style={styles.btnWrapper}>
         <Button
           title="회원가입"
@@ -24,9 +101,20 @@ export default function LoginScreen({ navigation }) {
   );
 }
 
+/* 스타일 */
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: "center", padding: 20, backgroundColor: "#fff" },
-  title: { fontSize: 24, fontWeight: "bold", marginBottom: 20, textAlign: "center" },
+  container: { 
+    flex: 1,
+    justifyContent: "center",
+    padding: 20,
+    backgroundColor: "#fff"
+  },
+  title: { 
+    fontSize: 24,
+    fontWeight: "bold",
+    marginBottom: 20,
+    textAlign: "center" 
+  },
   input: {
     borderWidth: 1,
     borderColor: "#ccc",
@@ -34,5 +122,7 @@ const styles = StyleSheet.create({
     borderRadius: 6,
     marginBottom: 12,
   },
-  btnWrapper: { marginTop: 12 }, // 버튼 사이 간격
+  btnWrapper: { 
+    marginTop: 12 
+  },
 });

--- a/my-app/src/screens/MyPageScreen.js
+++ b/my-app/src/screens/MyPageScreen.js
@@ -1,10 +1,10 @@
 import { View, Text, Button, StyleSheet, Image, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { removeTokens } from "../utils/tokenStorage";
 
 export default function MyPageScreen({ navigation }) {
   return (
     <View style={styles.container}>
-      {/* 프로필 */}
       <View style={styles.profile}>
         <Image
           source={{ uri: "https://placekitten.com/100/100" }}
@@ -21,7 +21,6 @@ export default function MyPageScreen({ navigation }) {
         </TouchableOpacity>
       </View>
 
-      {/* 메뉴 아이콘 영역 */}
       <View style={styles.menuRow}>
         <TouchableOpacity
           style={styles.menuItem}
@@ -68,7 +67,13 @@ export default function MyPageScreen({ navigation }) {
 
       {/* 로그아웃 */}
       <View style={{ marginTop: 30 }}>
-        <Button title="로그아웃" onPress={() => navigation.replace("Login")} />
+        <Button
+          title="로그아웃"
+          onPress={async () => {
+            await removeTokens();
+            navigation.replace("Login"); // 로그인 화면으로 이동
+          }}
+        />
       </View>
     </View>
   );

--- a/my-app/src/utils/axiosInstance.js
+++ b/my-app/src/utils/axiosInstance.js
@@ -1,0 +1,95 @@
+/*
+  axiosInstance 전체 설명 (요약)
+
+  - baseURL(BASE_URL)을 기반으로 axios 인스턴스를 생성하여 앱 전역에서 공통으로 사용합니다.
+  - 모든 API 요청에 대해:
+      ① 요청 인터셉터에서 Access Token을 자동으로 Authorization 헤더에 추가하고,
+      ② 응답 인터셉터에서 401(Unathorized)이 발생하면 Refresh Token을 이용해 Access Token을 자동 재발급합니다.
+
+  - Access/Refresh 토큰은 expo-secure-store(tokenStorage.js)에서 안전하게 로드/저장/삭제되며,
+    Refresh Token이 만료된 경우 removeTokens()를 실행하여 완전 로그아웃 처리합니다.
+
+  - refresh API는 BASE_URL/token/refresh/로 요청되며,
+    백엔드는 { access: "...", refresh: "..."} 형태의 JWT Pair 구조를 반환한다고 가정합니다.
+
+  - 이 파일 덕분에 개별 화면에서는 Authorization 헤더를 직접 신경 쓰지 않아도 되며,
+    토큰 만료에 따른 자동 재발급까지 백그라운드에서 처리됩니다.
+*/
+
+import axios from "axios";
+import { BASE_URL } from "../config/config";
+import {
+  getAccessToken,
+  getRefreshToken,
+  saveTokens,
+  removeTokens,
+} from "./tokenStorage";
+
+// axios 인스턴스 생성 (baseURL + timeout 설정)
+const api = axios.create({
+  baseURL: BASE_URL,
+  timeout: 8000,
+});
+
+// ─────────────────────────────
+// 요청 인터셉터: Access Token 자동 첨부
+// ─────────────────────────────
+api.interceptors.request.use(async (config) => {
+  // 저장된 Access Token 불러오기
+  const access = await getAccessToken();
+
+  // 토큰이 있으면 Authorization 헤더 추가
+  if (access) {
+    config.headers.Authorization = `Bearer ${access}`;
+  }
+
+  return config;
+});
+
+// ─────────────────────────────
+// 응답 인터셉터: 401 → Refresh Token으로 자동 재발급
+// ─────────────────────────────
+api.interceptors.response.use(
+  (res) => res,
+  async (err) => {
+    const original = err.config;
+
+    // 401 + 최초 1회 재시도 조건
+    if (err.response?.status === 401 && !original._retry) {
+      original._retry = true;
+
+      // 저장된 Refresh Token 가져오기
+      const refresh = await getRefreshToken();
+      if (!refresh) {
+        // Refresh Token이 없으면 강제 로그아웃
+        await removeTokens();
+        return Promise.reject(err);
+      }
+
+      try {
+        // Refresh Token으로 Access 재발급
+        const res = await axios.post(`${BASE_URL}/token/refresh/`, {
+          refresh,
+        });
+
+        const newAccess = res.data.access;
+
+        // 새 토큰 저장 (refresh는 기존 값 유지)
+        await saveTokens(newAccess, refresh);
+
+        // 실패했던 원래 요청에 새 토큰 적용
+        original.headers.Authorization = `Bearer ${newAccess}`;
+        return api(original);
+      } catch (e) {
+        // Refresh도 만료된 경우 → 완전 로그아웃
+        await removeTokens();
+        return Promise.reject(e);
+      }
+    }
+
+    // 401 이외의 에러는 그대로 반환
+    return Promise.reject(err);
+  }
+);
+
+export default api;

--- a/my-app/src/utils/tokenStorage.js
+++ b/my-app/src/utils/tokenStorage.js
@@ -1,0 +1,74 @@
+/*
+  tokenStorage 전체 설명 (요약)
+
+  - JWT Access Token / Refresh Token을 안전하게 저장·로드·삭제하는 유틸리티 파일입니다.
+  - 모바일(iOS/Android)에서는 expo-secure-store를 사용해 암호화된 스토리지에 저장하고,
+    웹 환경에서는 localStorage를 사용하도록 분기 처리합니다.
+
+  - saveTokens(access, refresh): 두 토큰을 저장
+  - getAccessToken(): 저장된 access 토큰 가져오기
+  - getRefreshToken(): 저장된 refresh 토큰 가져오기
+  - removeTokens(): 두 토큰 삭제(로그아웃 시 사용)
+
+  - axiosInstance.js와 함께 자동 인증/재발급 구조에 필수적으로 사용됩니다.
+*/
+
+import * as SecureStore from "expo-secure-store";
+import { Platform } from "react-native";
+
+const isWeb = Platform.OS === "web";
+
+/**
+ * saveTokens(access, refresh)
+ * - JWT Access / Refresh 토큰을 저장
+ * - 웹(localStorage)와 모바일(SecureStore)을 자동으로 분기
+ */
+export async function saveTokens(access, refresh) {
+  if (isWeb && typeof window !== "undefined" && window.localStorage) {
+    // 웹 환경
+    window.localStorage.setItem("access", access);
+    window.localStorage.setItem("refresh", refresh);
+  } else {
+    // 모바일 환경 (암호 저장)
+    await SecureStore.setItemAsync("access", access);
+    await SecureStore.setItemAsync("refresh", refresh);
+  }
+}
+
+/**
+ * getAccessToken()
+ * - 저장된 Access Token 불러오기
+ */
+export async function getAccessToken() {
+  if (isWeb && typeof window !== "undefined" && window.localStorage) {
+    return window.localStorage.getItem("access");
+  } else {
+    return await SecureStore.getItemAsync("access");
+  }
+}
+
+/**
+ * getRefreshToken()
+ * - 저장된 Refresh Token 불러오기
+ */
+export async function getRefreshToken() {
+  if (isWeb && typeof window !== "undefined" && window.localStorage) {
+    return window.localStorage.getItem("refresh");
+  } else {
+    return await SecureStore.getItemAsync("refresh");
+  }
+}
+
+/**
+ * removeTokens()
+ * - 로그아웃 시 두 토큰 삭제
+ */
+export async function removeTokens() {
+  if (isWeb && typeof window !== "undefined" && window.localStorage) {
+    window.localStorage.removeItem("access");
+    window.localStorage.removeItem("refresh");
+  } else {
+    await SecureStore.deleteItemAsync("access");
+    await SecureStore.deleteItemAsync("refresh");
+  }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

PY-154

## 📝 요약(Summary)
신규 생성
- /utils/tokenStorage.js       → SecureStore/LocalStorage 기반 토큰 CRUD
- /utils/axiosInstance.js      → 전역 axios 요청/응답 인터셉터 + 자동 토큰 재발급

변경된 파일
- /navigation/RootNavigator.js → 초기 진입 Login 설정 + LoginScreenWrapper 추가
- /screens/LoginScreen.js      → 실제 로그인 기능 구현 + 토큰 저장 로직 추가
- /screens/MyPageScreen.js     → 로그아웃 시 토큰 삭제 기능


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

기존 어플리케이션의 로그인 흐름, 네비게이션 구조, 토큰 기반 인증 로직을 전반적으로 개선했습니다.

기존 LoginScreen은 단순히 “로그인 버튼 클릭 → MainTabs 이동” 정도의 임시 기능만 있었으나,
이제는 백엔드 JWT 인증 구조에 맞춰 실제 로그인/토큰 저장/자동 로그인 기능이 모두 구현되었습니다.

자동 로그인 및 초기 진입 화면을 LoginScreen으로 고정하기 위해
RootNavigator 구조를 전면적으로 정리했습니다.

추가로 보안 강화를 위해 utils/tokenStorage.js, utils/axiosInstance.js 파일이 새로 생성되어 앱 전역 인증 흐름을 통합 관리하도록 구성했습니다.

---
### 백엔드 공유 사항

* refresh 토큰

현재 앱을 처음 실행할 때 refresh 토큰이 있으면 바로 MainTabs로 이동하도록 구현 되어있습니다. (즉, 자동 로그인)
settings.py에 `"REFRESH_TOKEN_LIFETIME": timedelta(days=1),` 이 있는 것을 보아 refresh 토큰의 기한이 1 일인 것으로 보입니다. 그럼 자동 로그인 기한이 하루가 맞는지 확인 부탁해요.


* Backend JWT 구조 재확인 필요

프론트는 access + refresh 토큰을 반환하는 JWT Pair 구조를 기준으로 동작합니다.
백엔드에서 Sliding Token이 아닌 다음 뷰를 사용하도록 요청드립니다:

TokenObtainPairView
TokenRefreshView

* 로그인 유저 정보

현재 회원 가입을 하지 않은 계정으로는 로그인이 안되는 상태입니다.
하지만, 회원 가입이 되어있는 계정으로 로그인 하더라도 아직은 임시 계정으로 로그인 된 것처럼 기능들이 동작하고 있으니, 추후 백엔드 쪽에서 변경이 생긴다면 프론트에서도 관련된 기능들 수정할 계획입니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
